### PR TITLE
Add Electron app with public key pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# test4
+# Electron Public Key Pinning Example
+
+This example shows how to pin the public key of a server in an Electron
+application. The application connects to `https://192.168.1.21` only when the
+server's public key matches the pinned hash.
+
+## Generating the Pinned Public Key
+
+Run the following command to extract and hash the server's public key (replace
+`192.168.1.21:443` with your server if different):
+
+```bash
+openssl s_client -connect 192.168.1.21:443 -showcerts </dev/null 2>/dev/null \
+  | openssl x509 -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl base64
+```
+
+Copy the resulting base64 hash and place it in `main.js` by replacing the value
+of `PINNED_PUBLIC_KEY_HASH`.
+
+## Running the App
+
+Install dependencies and start the application:
+
+```bash
+npm install
+npm start
+```
+
+When the certificate matches the pinned key, the response from the server will
+be shown in the application window.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Public Key Pinning Demo</title>
+</head>
+<body>
+  <h1>Public Key Pinning Demo</h1>
+  <pre id="response">Loading...</pre>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,48 @@
+const { app, BrowserWindow, session } = require('electron');
+const crypto = require('crypto');
+
+// Replace with the SHA-256 hash of your server's public key in base64
+const PINNED_PUBLIC_KEY_HASH = 'REPLACE_WITH_BASE64_HASH';
+
+function verifyCertificate(request, callback) {
+  const { hostname, certificate } = request;
+  if (hostname === '192.168.1.21') {
+    try {
+      const pem = `-----BEGIN CERTIFICATE-----\n${certificate.data.toString('base64')}\n-----END CERTIFICATE-----`;
+      const publicKey = crypto.createPublicKey(pem).export({ type: 'spki', format: 'der' });
+      const hash = crypto.createHash('sha256').update(publicKey).digest('base64');
+      if (hash === PINNED_PUBLIC_KEY_HASH) {
+        return callback(0);
+      }
+      return callback(-2);
+    } catch (err) {
+      console.error('Certificate verification failed', err);
+      return callback(-2);
+    }
+  }
+  return callback(0);
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  session.defaultSession.setCertificateVerifyProc(verifyCertificate);
+  createWindow();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/main.js
+++ b/main.js
@@ -2,8 +2,7 @@ const { app, BrowserWindow, session } = require("electron");
 const crypto = require("crypto");
 
 // Replace with the SHA-256 hash of your server's public key in base64
-const PINNED_PUBLIC_KEY_HASH =
-  "4db7a8f6e9d8693f0512b4244d3f0821d4b6874fb0aa486055ef5d9c8d13fe18";
+const PINNED_PUBLIC_KEY_HASH = "Tbeo9unYaT8FErQkTT8IIdS2h0+wqkhgVe9dnI0T/hg=";
 
 function verifyCertificate(request, callback) {
   const { hostname, certificate } = request;

--- a/main.js
+++ b/main.js
@@ -1,22 +1,30 @@
-const { app, BrowserWindow, session } = require('electron');
-const crypto = require('crypto');
+const { app, BrowserWindow, session } = require("electron");
+const crypto = require("crypto");
 
 // Replace with the SHA-256 hash of your server's public key in base64
-const PINNED_PUBLIC_KEY_HASH = 'REPLACE_WITH_BASE64_HASH';
+const PINNED_PUBLIC_KEY_HASH =
+  "4db7a8f6e9d8693f0512b4244d3f0821d4b6874fb0aa486055ef5d9c8d13fe18";
 
 function verifyCertificate(request, callback) {
   const { hostname, certificate } = request;
-  if (hostname === '192.168.1.21') {
+  if (hostname === "192.168.1.21") {
     try {
-      const pem = `-----BEGIN CERTIFICATE-----\n${certificate.data.toString('base64')}\n-----END CERTIFICATE-----`;
-      const publicKey = crypto.createPublicKey(pem).export({ type: 'spki', format: 'der' });
-      const hash = crypto.createHash('sha256').update(publicKey).digest('base64');
+      const pem = `-----BEGIN CERTIFICATE-----\n${certificate.data.toString(
+        "base64"
+      )}\n-----END CERTIFICATE-----`;
+      const publicKey = crypto
+        .createPublicKey(pem)
+        .export({ type: "spki", format: "der" });
+      const hash = crypto
+        .createHash("sha256")
+        .update(publicKey)
+        .digest("base64");
       if (hash === PINNED_PUBLIC_KEY_HASH) {
         return callback(0);
       }
       return callback(-2);
     } catch (err) {
-      console.error('Certificate verification failed', err);
+      console.error("Certificate verification failed", err);
       return callback(-2);
     }
   }
@@ -29,11 +37,11 @@ function createWindow() {
     height: 600,
     webPreferences: {
       nodeIntegration: true,
-      contextIsolation: false
-    }
+      contextIsolation: false,
+    },
   });
 
-  win.loadFile('index.html');
+  win.loadFile("index.html");
 }
 
 app.whenReady().then(() => {
@@ -41,8 +49,8 @@ app.whenReady().then(() => {
   createWindow();
 });
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
     app.quit();
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "electron-pin-example",
+  "version": "1.0.0",
+  "description": "Electron app with public key pinning",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^37.2.0"
+  }
+}

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,15 @@
+const https = require('https');
+
+function fetchMessage() {
+  https.get('https://192.168.1.21', res => {
+    let data = '';
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => {
+      document.getElementById('response').textContent = data;
+    });
+  }).on('error', err => {
+    document.getElementById('response').textContent = `Error: ${err.message}`;
+  });
+}
+
+window.onload = fetchMessage;


### PR DESCRIPTION
## Summary
- build minimal Electron app
- document public key pinning and how to generate the hash

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ae2e65eb883219238cadca3bd5761