### PR TITLE
Fix certificate verification for self-signed cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ npm start
 ```
 
 When the certificate matches the pinned key, the response from the server will
-be shown in the application window.
+be shown in the application window. The request is performed using Electron's
+`net` module so that the custom certificate verification logic is applied even
+when using a self‑signed certificate.

--- a/renderer.js
+++ b/renderer.js
@@ -1,15 +1,18 @@
-const https = require('https');
+const { net } = require('electron');
 
 function fetchMessage() {
-  https.get('https://192.168.1.21', res => {
+  const request = net.request('https://192.168.1.21');
+  request.on('response', res => {
     let data = '';
-    res.on('data', chunk => data += chunk);
+    res.on('data', chunk => (data += chunk));
     res.on('end', () => {
       document.getElementById('response').textContent = data;
     });
-  }).on('error', err => {
+  });
+  request.on('error', err => {
     document.getElementById('response').textContent = `Error: ${err.message}`;
   });
+  request.end();
 }
 
 window.onload = fetchMessage;


### PR DESCRIPTION
## Summary
- switch renderer requests to Electron's `net` module
- mention in README that the `net` module applies custom certificate verification

## Testing
- `npm start` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686aee8098288321a2a2da1bf0f425a9